### PR TITLE
Fix/3 interface specs

### DIFF
--- a/apps/tbc-cli/tests/051-int-generate.suite.ts
+++ b/apps/tbc-cli/tests/051-int-generate.suite.ts
@@ -22,8 +22,12 @@ describe('🐵 051 LETS-GO: tbc int generate (Generic)', () => {
         expect(existsSync(agentsPath)).toBe(true);
         const content = readFileSync(agentsPath, 'utf-8');
         expect(content).toContain('Mojo');
-        expect(content).toContain('ALWAYS read @tbc/root.md');
-        expect(content).toContain('@dex/core.md');
+        expect(content).toContain('ALWAYS read @sys/root.md');
+        expect(content).toContain('@dex/sys.digest.txt');
+        expect(content).toContain('ALWAYS READ FULLY');
+        expect(content).toContain('sys.digest.txt');
+        expect(content).toContain('skills.jsonl');
+        expect(content).toContain('tbc dex rebuild');
     });
 
     test('should be idempotent (running twice changes nothing)', () => {

--- a/apps/tbc-cli/tests/052-int-gemini.suite.ts
+++ b/apps/tbc-cli/tests/052-int-gemini.suite.ts
@@ -22,6 +22,10 @@ describe('🐵 052 LETS-GO: tbc int generate (Gemini CLI)', () => {
         expect(existsSync(geminiPath)).toBe(true);
         const content = readFileSync(geminiPath, 'utf-8');
         expect(content).toContain('Mojo');
-        expect(content).toContain('ALWAYS read @tbc/root.md');
+        expect(content).toContain('ALWAYS read @sys/root.md');
+        expect(content).toContain('ALWAYS READ FULLY');
+        expect(content).toContain('sys.digest.txt');
+        expect(content).toContain('skills.jsonl');
+        expect(content).toContain('tbc dex rebuild');
     });
 });

--- a/apps/tbc-cli/tests/053-int-goose.suite.ts
+++ b/apps/tbc-cli/tests/053-int-goose.suite.ts
@@ -24,7 +24,11 @@ describe('🐵 053 LETS-GO: tbc int generate (Goose)', () => {
         expect(existsSync(goosePath)).toBe(true);
         const content = readFileSync(goosePath, 'utf-8');
         expect(content).toContain('Mojo');
-        expect(content).toContain('ALWAYS read @tbc/root.md');
+        expect(content).toContain('ALWAYS read @sys/root.md');
+        expect(content).toContain('ALWAYS READ FULLY');
+        expect(content).toContain('sys.digest.txt');
+        expect(content).toContain('skills.jsonl');
+        expect(content).toContain('tbc dex rebuild');
         expect(content).toContain('interaction');
     });
 

--- a/apps/tbc-cli/tests/054-int-github-copilot.suite.ts
+++ b/apps/tbc-cli/tests/054-int-github-copilot.suite.ts
@@ -31,7 +31,11 @@ describe('🐵 054 LETS-GO: tbc int generate (GitHub Copilot)', () => {
         expect(content).toContain('tools:');
         expect(content).toContain('- execute');
         expect(content).toContain('For the interaction, you will act as Mojo.');
-        expect(content).toContain('ALWAYS read @tbc/root.md');
+        expect(content).toContain('ALWAYS read @sys/root.md');
+        expect(content).toContain('ALWAYS READ FULLY');
+        expect(content).toContain('sys.digest.txt');
+        expect(content).toContain('skills.jsonl');
+        expect(content).toContain('tbc dex rebuild');
     });
 
     test('should be idempotent (running twice changes nothing)', () => {

--- a/apps/tbc-cli/tests/055-int-kilocode.suite.ts
+++ b/apps/tbc-cli/tests/055-int-kilocode.suite.ts
@@ -29,7 +29,11 @@ describe('🐵 055 LETS-GO: tbc int generate (Kilocode)', () => {
         expect(content).toContain('- mcp');
         expect(content).toContain('source: project');
         expect(content).toContain('name: Mojo');
-        expect(content).toContain('ALWAYS read @tbc/root.md');
+        expect(content).toContain('ALWAYS read @sys/root.md');
+        expect(content).toContain('ALWAYS READ FULLY');
+        expect(content).toContain('sys.digest.txt');
+        expect(content).toContain('skills.jsonl');
+        expect(content).toContain('tbc dex rebuild');
         expect(content).toContain('interaction');
         expect(content).toMatch(/slug: mojo\s+name: Mojo/);
     });

--- a/apps/tbc-cli/tests/150-int.suite.ts
+++ b/apps/tbc-cli/tests/150-int.suite.ts
@@ -34,7 +34,11 @@ describe('🦍 150 LETS-GO: tbc int (Kong/Next)', () => {
         const agentsPath = join(TBC_ROOT_NEXT, 'AGENTS.md');
         expect(existsSync(agentsPath)).toBe(true);
         const content = readFileSync(agentsPath, 'utf-8');
-        expect(content).toContain('ALWAYS read @tbc/root.md');
+        expect(content).toContain('ALWAYS read @sys/root.md');
+        expect(content).toContain('ALWAYS READ FULLY');
+        expect(content).toContain('sys.digest.txt');
+        expect(content).toContain('skills.jsonl');
+        expect(content).toContain('tbc dex rebuild');
         expect(content).toContain('Kong');
     });
 

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -1,0 +1,5 @@
+## Release Notes
+
+### Third Brain Companion v0.4.2
+
+- fix: rename system paths from tbc/dex to sys convention in interface specs

--- a/packages/tbc-system/src/assets/templates/role-definition.md
+++ b/packages/tbc-system/src/assets/templates/role-definition.md
@@ -1,5 +1,5 @@
-At the start of an interaction, ALWAYS read @tbc/root.md file at the root of the repository, and follow all specifications from it recursively until you have read and understood. 
+At the start of an interaction, ALWAYS read @sys/root.md file at the root of the repository, and follow all specifications from it recursively until you have read and understood. 
 
-ALWAYS READ FULLY: @dex/core.md @dex/extensions.md @dex/skills.md when available or execute the script to generate it. 
+ALWAYS READ FULLY: @dex/sys.digest.txt @dex/skills.jsonl when available or use `tbc dex rebuild` to generate and read it. 
 
 For the interaction, you will act as {{companionName}}.


### PR DESCRIPTION
## Summary

Fixes stale system path references across all agent interface templates and integration tests, introduced after the `0.4.0`/`0.4.1` upgrades.

Closes #3

## Problem

Post `0.3.0 → 0.4.x` migration, system paths were renamed (`core.md`, `extensions.md`, `skills.md` → `sys.digest.txt`, `skills.jsonl`) but the generated templates for all agent interfaces still referenced the old paths.

## Changes

- Renames `@tbc/root.md` → `@sys/root.md` in role definition templates
- Replaces `@dex/core.md` with `@dex/sys.digest.txt`
- Removes `@dex/extensions.md` and `@dex/skills.md`; adds `@dex/skills.jsonl`
- Adds `tbc dex rebuild` command reference
- Updates integration tests across all affected interfaces

## Interfaces fixed

| # | Interface | Test |
|---|-----------|------|
| 051 | Generic (`AGENTS.md`) | ✅ |
| 052 | Gemini CLI | ✅ |
| 053 | Goose (`.goosehints`) | ✅ |
| 054 | GitHub Copilot | ✅ |
| 055 | Kilocode (`.kilocodemodes`) | ✅ |
| 150 | Kong/Next (probe, generic, goose, copilot) | ✅ |

## Notes

Purely mechanical rename across templates and tests - no logic changes. Safe to merge to `dev` ahead of next release.