### PR TITLE
fix(dex): ensure deterministic JSONL output on rebuild

### DIFF
--- a/apps/tbc-cli/tests/0600-dex-rebuild.suite.ts
+++ b/apps/tbc-cli/tests/0600-dex-rebuild.suite.ts
@@ -50,4 +50,31 @@ This was added manually to test dex rebuild.`;
         const digestContent = readFileSync(sysDigestPath, 'utf-8');
         expect(digestContent).toContain('sys');
     });
+
+    test('should produce deterministic JSONL output on repeated rebuilds', async () => {
+        const { success: s1 } = runMonorepoCommand(TBC_ROOT, CLI_TARGET, [
+            'dex',
+            'rebuild',
+            '--root',
+            TBC_ROOT,
+        ]);
+        expect(s1).toBe(true);
+
+        const firstOutput = readFileSync(dexShardPath, 'utf-8');
+        const firstDigest = readFileSync(sysDigestPath, 'utf-8');
+
+        const { success: s2 } = runMonorepoCommand(TBC_ROOT, CLI_TARGET, [
+            'dex',
+            'rebuild',
+            '--root',
+            TBC_ROOT,
+        ]);
+        expect(s2).toBe(true);
+
+        const secondOutput = readFileSync(dexShardPath, 'utf-8');
+        const secondDigest = readFileSync(sysDigestPath, 'utf-8');
+
+        expect(firstOutput).toBe(secondOutput);
+        expect(firstDigest).toBe(secondDigest);
+    });
 });

--- a/apps/tbc-cli/tests/1600-dex-rebuild.suite.ts
+++ b/apps/tbc-cli/tests/1600-dex-rebuild.suite.ts
@@ -51,4 +51,31 @@ This was added manually to test dex rebuild on Kong.`;
         const digestContent = readFileSync(sysDigestPath, 'utf-8');
         expect(digestContent).toContain('sys');
     });
+
+    test('should produce deterministic JSONL output on repeated rebuilds', async () => {
+        const { success: s1 } = runMonorepoCommand(TBC_ROOT_NEXT, CLI_TARGET, [
+            'dex',
+            'rebuild',
+            '--root',
+            TBC_ROOT_NEXT,
+        ]);
+        expect(s1).toBe(true);
+
+        const firstOutput = readFileSync(dexShardPath, 'utf-8');
+        const firstDigest = readFileSync(sysDigestPath, 'utf-8');
+
+        const { success: s2 } = runMonorepoCommand(TBC_ROOT_NEXT, CLI_TARGET, [
+            'dex',
+            'rebuild',
+            '--root',
+            TBC_ROOT_NEXT,
+        ]);
+        expect(s2).toBe(true);
+
+        const secondOutput = readFileSync(dexShardPath, 'utf-8');
+        const secondDigest = readFileSync(sysDigestPath, 'utf-8');
+
+        expect(firstOutput).toBe(secondOutput);
+        expect(firstDigest).toBe(secondDigest);
+    });
 });

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -5,3 +5,4 @@
 - fix(templates): rename system paths from tbc/dex to sys convention in interface specs
 - feat(pi): add Pi agent interface integration plugin
 - test(cli): add Pi integration test and renumber tests to 4-digit scheme
+- fix(dex): ensure deterministic JSONL output by sorting records by id

--- a/packages/tbc-record-fs/src/fs-store.ts
+++ b/packages/tbc-record-fs/src/fs-store.ts
@@ -312,6 +312,7 @@ class FSStore implements RecordStore {
             }
 
             for (const [kind, records] of Object.entries(kindGroups)) {
+                records.sort((a, b) => a.id.localeCompare(b.id));
                 const indexPath = join(dexDir, `${collection}.${kind}.jsonl`);
                 this.updateDexShard(indexPath, records);
             }


### PR DESCRIPTION
## Summary

Fixes non-deterministic JSONL record ordering on `tbc dex rebuild`, restoring the stable output that existed prior to `0.4.0`.

Closes #7

## Problem

Before `0.3.0`, dex output was deterministic. The `0.4.0` migration to JSONL format introduced unordered record writes, causing JSONL shards to be shuffled on every full rebuild. For TBC roots tracked with `git`, this produces noisy diffs and makes it hard to determine whether a `git commit` is genuinely needed.

## Fix

Records are now sorted by ID before being written to JSONL shards, guaranteeing consistent output across rebuilds regardless of the order in which records are processed internally.

## Tests

- Adds stability tests to both `0600` and `1600` dex-rebuild suites
- Each test runs `tbc dex rebuild` twice and asserts the output is identical across both runs

## Notes

No changes to record content or schema - sort is applied at write time only. Safe to merge to `dev`.