### PR TITLE
feat(skills): clarify --type filter behavior in tbc-mem-ops documentation

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -6,3 +6,4 @@
 - feat(pi): add Pi agent interface integration plugin
 - test(cli): add Pi integration test and renumber tests to 4-digit scheme
 - fix(dex): ensure deterministic JSONL output by sorting records by id
+- feat(skills): clarify --type filter behavior in tbc-mem-ops skill documentation

--- a/packages/tbc-system/src/assets/skills/core/tbc-mem-ops/SKILL.md
+++ b/packages/tbc-system/src/assets/skills/core/tbc-mem-ops/SKILL.md
@@ -51,6 +51,13 @@ Options:
   -l, --limit <number>  Limit the number of results (default: 10)
   -h, --help            display help for command
 ```
+
+> **Important**: The `--type` filter restricts search to only that record type. 
+> - `tbc mem recall John` searches all record types
+> - `tbc mem recall --type party John` searches only party-type records
+> 
+> When comparing recall results with `rg` (ripgrep), use unfiltered recall (`tbc mem recall <query>`) to ensure equivalent search scope.
+
 * **Assimilate**: Use `tbc mem assimilate` to replicate memory records across all RecordStore providers.
 ```bash
 $ tbc mem assimilate --help


### PR DESCRIPTION
## Summary

Improves agent steering in the `tbc-mem-ops` skill by clarifying the narrowing effect of the `--type` filter on recall scope.

## Problem

The `SKILLS.md` instruction for `--type` did not make it explicit that the filter restricts recall to *only* that record type. Agents powering the Companion could reasonably interpret it as a loose hint, leading to incomplete recall results going unnoticed.

## Changes

- Adds an **important note** to `SKILLS.md` explaining that `--type` is a hard scope restriction, not a preference
- Adds examples contrasting filtered vs. unfiltered `recall` commands to guide agent decision-making
- Includes guidance on using `ripgrep` to verify equivalent search scope
- Fixes missing newline at end of file

## Impact

Companion agents will be better steered when deciding whether to apply `--type` — reducing the risk of silently narrowed recall in contexts where broader search was intended.

## Notes

No functional code changes. Effect is agent behaviour improvement via updated skill instructions.