### PR TITLE
fix(tbc-memory): ensure deterministic dex index ordering after assimilate (#10)

### DIFF
--- a/apps/tbc-cli/tests/0301-mem-recall.suite.ts
+++ b/apps/tbc-cli/tests/0301-mem-recall.suite.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { runMonorepoCommand } from '../../../scripts/common';
-import { CLI_TARGET, SANDBOX, TBC_ROOT, UUID_SEARCH_REGEX } from './test-helper';
+import { CLI_TARGET, NON_TBC_ROOT, SANDBOX, TBC_ROOT, UUID_SEARCH_REGEX } from './test-helper';
 
 describe('🐵 0301 LETS-GO: tbc mem recall', () => {
 
@@ -117,7 +117,7 @@ describe('🐵 0301 LETS-GO: tbc mem recall', () => {
             'mem',
             'recall',
             '--root',
-            SANDBOX,
+            NON_TBC_ROOT,
         ]);
         expect(success).toBe(true);
         expect(output).toContain('error | recall-flow');

--- a/apps/tbc-cli/tests/0500-int-probe.suite.ts
+++ b/apps/tbc-cli/tests/0500-int-probe.suite.ts
@@ -5,6 +5,7 @@ import {
     SANDBOX,
     CLI_TARGET,
     runMonorepoCommand,
+    NON_TBC_ROOT,
 } from './test-helper';
 
 describe('🐵 0500 LETS-GO: tbc int probe', () => {
@@ -33,7 +34,7 @@ describe('🐵 0500 LETS-GO: tbc int probe', () => {
             'int',
             'probe',
             '--root',
-            SANDBOX,
+            NON_TBC_ROOT,
         ]);
         expect(success).toBe(true);
         expect(output).toContain('DEGRADED');

--- a/apps/tbc-cli/tests/test-helper.ts
+++ b/apps/tbc-cli/tests/test-helper.ts
@@ -1,5 +1,5 @@
 import { expect } from 'bun:test';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { Database } from 'bun:sqlite';
 
@@ -11,14 +11,17 @@ export const CLI_ENTRY = join(PROJECT_ROOT, 'apps/tbc-cli/src/index.ts');
 export const TEST_BINARY = process.env.TBC_TEST_BINARY;
 export const CLI_TARGET = TEST_BINARY ? join(PROJECT_ROOT, TEST_BINARY) : CLI_ENTRY;
 
-// Mojo Baseline (Standard FS-only 0.3/0.4 fallback)
+export const NON_TBC_ROOT = join(PROJECT_ROOT, '_test', 'non-tbc');
+!existsSync(NON_TBC_ROOT) && mkdirSync(NON_TBC_ROOT);
+
+// Mojo Baseline
 // - companion: mojo
 // - prime: jojo
 export const SANDBOX = join(PROJECT_ROOT, '_test');
 export const TBC_ROOT = join(SANDBOX, 'mojo');
 export const TBC_DB = join(TBC_ROOT, 'records.db');
 
-// Kong "Next" (Dual FS + SQLite 0.4 standard)
+// Kong "Next"
 // - companion: kong
 // - prime: zilla
 export const SANDBOX_NEXT = join(PROJECT_ROOT, '_test');

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -8,3 +8,4 @@
 - fix(dex): ensure deterministic JSONL output by sorting records by id
 - feat(skills): clarify --type filter behavior in tbc-mem-ops skill documentation
 - fix(system,skills): process records without frontmatter as-is instead of skipping them (resolves issue with dex/skill.jsonl)
+- fix(mem): ensure deterministic dex index ordering by invoking dex-rebuild after assimilate

--- a/packages/tbc-memory/src/ops/assimilate-flow.ts
+++ b/packages/tbc-memory/src/ops/assimilate-flow.ts
@@ -1,9 +1,10 @@
 import assert from 'node:assert';
 
 import { Node } from 'pocketflow';
-import { HAMIFlow, HAMINode, HAMINodeConfigValidateResult, validateAgainstSchema, ValidationSchema } from '@hami-frameworx/core';
+import { HAMIFlow, HAMINode, validateAgainstSchema } from '@hami-frameworx/core';
+import type { HAMINodeConfigValidateResult, ValidationSchema } from '@hami-frameworx/core';
 
-import { Shared } from '../types';
+import type { Shared } from '../types';
 
 interface Config {
     verbose?: boolean;
@@ -19,11 +20,11 @@ const ConfigSchema: ValidationSchema = {
 };
 
 class StartNode extends HAMINode<Shared, Config> {
-    kind(): string {
+    override kind(): string {
         return 'tbc-memory:assimilate-flow-start';
     }
 
-    async post(shared: Shared): Promise<string> {
+    override async post(shared: Shared): Promise<string> {
         shared.stage = shared.stage || {};
         shared.system = shared.system || {};
 
@@ -43,7 +44,7 @@ export class AssimilateFlow extends HAMIFlow<Shared, Config> {
         this.startNode = startNode;
     }
 
-    kind(): string {
+    override kind(): string {
         return 'tbc-memory:assimilate-flow';
     }
 
@@ -159,7 +160,12 @@ export class AssimilateFlow extends HAMIFlow<Shared, Config> {
                 protocolKey: 'mem',
             }))
 
-            // Step 4: Feedback
+            // Step 4: Invoke dex-rebuild to ensure deterministic index ordering
+            .next(n('tbc-system:dex-rebuild-flow', {
+                verbose: this.config?.verbose,
+            }))
+
+            // Step 5: Feedback
             .next(n('core:mutate', {
                 mutate: (s: Shared) => {
                     const count = s.record?.records?.length || 0;


### PR DESCRIPTION
## fix(tbc-memory): ensure deterministic dex index ordering after assimilate (#10)

### Problem
`tbc memory assimilate` — which reads all memory records and broadcasts them across `FSRecord` and `SQLiteRecord` — was leaving `.jsonl` index files in a non-deterministic order after completion.

For TBC instances that track state via git, this produced noisy, spurious diffs on every assimilate run, making it difficult to determine whether a commit was genuinely warranted.

### Root Cause
The assimilate flow's read-broadcast cycle completed without invoking `dex rebuild`. Deterministic ordering was previously enforced on the `dex rebuild` path (fixed in #8 for issue #7), but the assimilate path had the same underlying gap and was never covered by that fix.

### Solution
Invoke `dex-rebuild-flow` at the conclusion of the assimilate step. This mirrors the fix from #8 and re-imposes stable, consistent JSONL record ordering after every assimilate run.

### Changes
| Commit | Scope | Description |
|--------|-------|-------------|
| `f23ffc0` | fix(tbc-memory) | Invoke `dex-rebuild-flow` after assimilate to guarantee deterministic dex index ordering and JSONL sequence integrity |
| `26dc975` | test(cli) | Update `mem-recall` and `int-probe` integration test suites to use `NON_TBC_ROOT` instead of `SANDBOX` for non-TBC root validation; add `NON_TBC_ROOT` constant and ensure directory creation in test-helper |
| `42fa760` | docs(release-notes) | Document the fix for consistent JSONL output after assimilate |

### Testing
Integration tests updated to use a proper `NON_TBC_ROOT` directory, improving test accuracy for CLI behavior with non-TBC roots.

### Related
Closes #10 | Related: #7, #8